### PR TITLE
ci: update dockerfile and deploy action

### DIFF
--- a/.github/workflows/push-container.yml
+++ b/.github/workflows/push-container.yml
@@ -1,58 +1,44 @@
-name: Push Container
-
-#TODO: Add deployment
+name: Deploy
 
 on:
-  workflow_run:
-    workflows: ["Build & Test"]
+  workflow_dispatch:
+  push:
     branches:
       - main
-    types:
-      - completed
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-and-push-image:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
-    name: Build & Push Container
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-      # Create a commit SHA-based tag for the container repositories
-      - name: Create SHA Container Tag
-        id: sha_tag
-        run: |
-          tag=$(cut -c 1-7 <<< $GITHUB_SHA)
-          echo "::set-output name=tag::$tag"
-
-      # Check out the current repository in the `reagurk` subdirectory
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          path: reagurk
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Github Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN  }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build and push the container to the GitHub Container
-      # Repository. The container will be tagged as "latest"
-      # and with the short SHA of the commit.
-      - name: Build and push
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
-          context: reagurk/
-          file: reagurk/Dockerfile
+          context: .
           push: true
-          cache-from: type=registry,ref=ghcr.io/gurkult/reagurk:latest
-          cache-to: type=inline
-          tags: |
-            ghcr.io/gurkult/reagurk:latest
-            ghcr.io/gurkult/reagurk:${{ steps.sha_tag.outputs.tag }}
-          build-args: |
-            git_sha=${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .vscode
+/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-## This container will build the website and store it in the /app/build folder.
-# We use a scratch image to have a minimal container acting as an archive.
-
 FROM node:latest AS builder
 
 WORKDIR /app
-COPY ./reagurk .
 
-RUN yarn install && yarn build
+COPY ./reagurk/package.json ./reagurk/yarn.lock ./
+RUN yarn set version berry
+RUN echo "nodeLinker: node-modules" >> .yarnrc.yml
+RUN yarn install
+
+COPY ./reagurk .
+RUN yarn build
 
 FROM scratch
 
-COPY --from=builder /app/build /app/build
+COPY --from=builder /app/build /

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Gurkan Gang central command
 
+To run with Docker, use `docker build . --output=build` and serve the `build` directory.
+
 ## Dev instructions
 
 Always create a new branch off of the develop branch to make your changes on.


### PR DESCRIPTION
This PR updates the Dockerfile to be able to generate the static files for the site. It is necessary that the build command is run with the `--output` flag (e.g. `docker build . --output=build`). An action for pushing to [ghcr.io](https://ghcr.io) is also added.