### PR TITLE
add target=_blank footer

### DIFF
--- a/reagurk/src/components/footer.tsx
+++ b/reagurk/src/components/footer.tsx
@@ -18,11 +18,11 @@ export default function Footer(): JSX.Element {
             Made with ♥ in Gurkland
           </p>
           <span className="inline-flex sm:ml-auto sm:mt-0 mt-4 justify-center sm:justify-start">
-            <a className="text-gray-400" href={github}>
-              <img className='w-10 pt-6 ' src={githubIcon} />
+            <a className="text-gray-400" target="_blank" rel="noreferrer" href={github}>
+              <img className="w-10 pt-6" src={githubIcon} />
             </a>
-            <a className="ml-3 text-gray-400" href={serverInvite}>
-              <img className='w-10 pt-7' src={discordIcon} />
+            <a className="ml-3 text-gray-400" target="_blank" rel="noreferrer" href={serverInvite}>
+              <img className="w-10 pt-7" src={discordIcon} />
             </a>
           </span>
         </div>


### PR DESCRIPTION
I changed the footer links to open in a new tab. This is to be consistent with the rest of the site and to be more convenient for a user by allowing them to look at our github and discord without the need to exit the site.